### PR TITLE
improve: $ARGUMENTS未指定時に現在のブランチのPR自動取得機能を追加

### DIFF
--- a/self_review_pr.md
+++ b/self_review_pr.md
@@ -44,6 +44,16 @@ Claude Codeのコマンドとして実行され、引数として渡されたPul
 # Claude Codeのコマンド引数からPull Request URLを取得
 PR_URL="$ARGUMENTS"
 
+# $ARGUMENTSが空の場合、現在のブランチのPRを取得
+if [ -z "$PR_URL" ]; then
+  PR_URL=$(gh pr view --json url --jq '.url' 2>/dev/null || echo "")
+  if [ -z "$PR_URL" ]; then
+    echo "エラー: Pull RequestのURLが指定されていません。また、現在のブランチに紐づくPRも見つかりませんでした。"
+    exit 1
+  fi
+  echo "現在のブランチのPull Request URLを使用します: $PR_URL"
+fi
+
 # gh pr viewでPR情報を取得
 PR_INFO=$(gh pr view "$PR_URL" --json number,headRepositoryOwner,headRepository,title,body,author,state,headRefName,baseRefName,changedFiles,additions,deletions,createdAt,commits,statusCheckRollup,mergeable)
 

--- a/triage_pr_comments.md
+++ b/triage_pr_comments.md
@@ -9,6 +9,17 @@ Pull RequestのURL: $ARGUMENTS
 ```bash
 # Pull RequestのURLから情報を取得
 PR_URL="$ARGUMENTS"
+
+# $ARGUMENTSが空の場合、現在のブランチのPRを取得
+if [ -z "$PR_URL" ]; then
+  PR_URL=$(gh pr view --json url --jq '.url' 2>/dev/null || echo "")
+  if [ -z "$PR_URL" ]; then
+    echo "エラー: Pull RequestのURLが指定されていません。また、現在のブランチに紐づくPRも見つかりませんでした。"
+    exit 1
+  fi
+  echo "現在のブランチのPull Request URLを使用します: $PR_URL"
+fi
+
 echo "=== Pull Request基本情報 ==="
 
 # gh pr viewでPR情報を取得


### PR DESCRIPTION
triage_pr_comments.mdとself_review_pr.mdの両方で、
$ARGUMENTSが空の場合に`gh pr view --json url --jq '.url'`を使って 現在のブランチに紐づくPull Requestを自動取得する機能を追加。

エラーハンドリングも含め、PRが見つからない場合は適切な
エラーメッセージを表示する。