### PR TITLE
docs: semantic_commit.mdをgit-sequential-stageのワイルドカード機能に対応

### DIFF
--- a/semantic_commit.md
+++ b/semantic_commit.md
@@ -323,15 +323,6 @@ git diff HEAD > .claude/tmp/current_changes.patch
 git diff HEAD --name-only | xargs -I {} sh -c 'printf "%s: " "{}"; git diff HEAD {} | grep -c "^@@"'
 ```
 
-
-## 注意事項
-
-- **使用しないコマンド**: `git add`、`git checkout`、`git restore`、`git reset`、`git stash`
-  - **重要**: `git add`は新規ファイルの intent-to-add (`git add -N`) のみ使用可能
-  - ステージングはすべて`git-sequential-stage`が自動的に行う
-- **対話的操作の回避**: `git add -p`などのインタラクティブなコマンドは使用しない
-- **hunk番号の確認**: 必ず最新の差分で各ファイルのhunk番号を確認してから指定
-
 ## 背景と設計思想
 
 LLM Agentは複数の論理的な変更を1つのコミットにまとめてしまう傾向があります。`git-sequential-stage`ツールは、人間が`git add -p`で行う作業を、**シンプルなコマンド実行だけで**実現できるようにします。


### PR DESCRIPTION
## 概要

semantic_commit.mdのドキュメントを更新し、git-sequential-stage v0.2.0で追加されたワイルドカード機能に対応しました。

## 修正が必要になった背景

[syou6162/git-sequential-stage#37](https://github.com/syou6162/git-sequential-stage/pull/37)でワイルドカード機能が追加されたため、semantic_commitコマンドのドキュメントも更新が必要でした。

ワイルドカード機能により、ファイル全体をステージングする際に`file:*`の形式で指定できるようになりましたが、現在のgit-sequential-stageの実装ではまだワイルドカードはサポートされていないため、実際の使用では従来通りhunk番号を明示的に指定する必要があります。

## 変更内容

### ワイルドカード機能のドキュメント化
- 使用方法にワイルドカード（`*`）の説明を追加
- ワイルドカード使用の適切な判断基準を明記
- 「hunkを数えるのが面倒」という理由での使用を禁止する警告を追加
- 実行例をワイルドカード使用を含む形に更新

### 注意事項セクションの削除
- フックで制御されている内容のため、テキストベースの注意事項は不要と判断
- 「使用しないコマンド」の記述を削除（フックで自動的に防がれるため）

## コミット履歴

- `f9272d0` docs: git-sequential-stageのワイルドカード機能をドキュメント化
- `90b12c9` docs: 注意事項セクションを削除