### PR TITLE
feat: codex CLI失敗時にcopilot CLIへフォールバックする手順を追加

### DIFF
--- a/skills/codex-plan-review/SKILL.md
+++ b/skills/codex-plan-review/SKILL.md
@@ -190,6 +190,14 @@ echo "以下のplanファイルを日本語でレビューしてください。
 
 </example>
 
+**Codex CLIが失敗した場合のフォールバック：**
+
+`codex review -` の終了コードが0以外（weekly limitやその他のエラー）の場合、同じプロンプトをcopilot CLIで実行してください：
+
+```bash
+echo "<同じレビュープロンプト>" | copilot --model gpt-5.3-codex
+```
+
 <important>
 
 - ファイルの内容ではなく、ファイルパスを渡すことで、Codexが直接ファイルを読み取ります

--- a/skills/codex-review/SKILL.md
+++ b/skills/codex-review/SKILL.md
@@ -133,6 +133,14 @@ echo "<デフォルトブランチ名>ブランチとの差分を日本語でレ
 
 </example>
 
+**Codex CLIが失敗した場合のフォールバック：**
+
+`codex review -` の終了コードが0以外（weekly limitやその他のエラー）の場合、同じプロンプトをcopilot CLIで実行してください：
+
+```bash
+echo "<同じレビュープロンプト>" | copilot --model gpt-5.3-codex
+```
+
 <important>
 
 - ファイルの内容ではなく、ファイルパスを渡すことで、Codexが直接ファイルを読み取ります


### PR DESCRIPTION
## 概要

codex CLIがweekly limitなどで使えない場合に、copilot CLIへ自動的にフォールバックしてレビューを継続できるようにした。

## 背景

codex CLIにはweekly limitがあり、上限に達するとレビューが実行できない。現状、codex CLIが失敗した場合のフォールバック処理が未定義だったため、代替手段としてcopilot CLIを利用する手順を追加した。

## 変更内容

- `skills/codex-review/SKILL.md`: Codex CLIでのレビュー実行セクションにcopilotフォールバック手順を追加
- `skills/codex-plan-review/SKILL.md`: 同様にcopilotフォールバック手順を追加
- フォールバック時のコマンド形式: `echo "<レビュープロンプト>" | copilot --model gpt-5.3-codex`
