### PR TITLE
chore: semantic-committingスキルのフロントマターを整理

### DIFF
--- a/skills/semantic-committing/SKILL.md
+++ b/skills/semantic-committing/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: semantic-committing
 description: コミット時、「commit」「git add」「変更を分割」の言及時に使用。git diffを分析し、変更を論理的な意味単位に分割してコミットする。git-sequential-stageでhunk単位のステージングを行う。
-allowed-tools: Bash, Write, Edit, Read
-model: sonnet
-context: fork
+compatibility: Requires git and git-sequential-stage (https://github.com/syou6162/git-sequential-stage)
 ---
 
 # 意味のある最小単位でコミットする


### PR DESCRIPTION
## 概要

`semantic-committing` スキルのfrontmatterをAgent Skills仕様に準拠させ、ポータブルスキルとして整備する。

## 背景

プロジェクト「claude-code-commands → agent-skills クロスエージェント対応」の一環として、スキルをClaude Code以外のエージェント（Codex CLI, Gemini CLI等）でも使えるポータブルな形式に移行している。 https://github.com/syou6162/agent-skills/pull/102 （YAS-212）で確立したパターンに従い、semantic-committingスキルにも同一アプローチを適用する。

## 変更内容

- `allowed-tools: Bash, Write, Edit, Read` を削除 — 値がClaude Code固有のツール名であり他エージェントで認識されない
- `model: sonnet` を削除 — Agent Skills仕様に存在しないClaude Code固有の拡張フィールド
- `context: fork` を削除 — Agent Skills仕様に存在しないClaude Code固有の拡張フィールド
- `compatibility: Requires git and git-sequential-stage (https://github.com/syou6162/git-sequential-stage)` を追加 — 外部CLIツール依存を明示

## 関連情報

- https://linear.app/yasuhisa/issue/YAS-208/semantic-committing-のポータブル化方針を決定context-fork-git-sequential-stage-依存
- https://github.com/syou6162/agent-skills/pull/102
